### PR TITLE
Remove dashes to appease `shopify theme check`

### DIFF
--- a/src/schematic.js
+++ b/src/schematic.js
@@ -377,9 +377,9 @@ class Schematic {
     const schema = this.compileSchema(importFile);
 
     const newSchema = [
-      '{%- schema -%}',
+      '{% schema %}',
         JSON.stringify(schema, null, 2),
-      '{%- endschema -%}',
+      '{% endschema %}',
     ].join('\n');
 
     let newContents;


### PR DESCRIPTION
simple fix for https://github.com/Shopify/liquid/issues/1594

per this issue the cli command `shopify theme check` does not recognize the dashes in `{%- schema -%}` and `{%- endschema -%}` and marks them as the error: `'schema' tag was never closed` for every file.

not a huge deal but just noticed while I was running the command to see if my theme could be streamlined.