### PR TITLE
✨ update section method to receive props object, with sane defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Since it also sucks creating a bunch of schema from scratch for every project, S
 ### Quality of life methods & objects
 | Method or property | Arguments | Description | Example |
 | --- | --- | --- | --- |
-| section | name, [tag] | Returns starter object for section schema (name, preset name, and optionally tag) | `...app.section('Icon and heading', 'div')` |
+| section | name, [props] | Returns starter object for section schema (name, preset name, and optionally tag) | `...app.section('Icon and heading', { class: 'section', tag: 'div' })` |
 | option | id, label | Returns option object | `app.option('text-left', 'Left align')` |
 | types | | Returns object of camelCase input types | `app.types.bgColor; // returns "color_background"` |
 | templates | | Returns object of camelCase template names | `app.templates.activateAccount; // returns "customers/activate_account"` |

--- a/src/helpers/methods.js
+++ b/src/helpers/methods.js
@@ -153,16 +153,20 @@ const methods =
     return obj;
   },
 
-  section: (name, tag = 'section') => {
-    return {
-      name: name,
-      tag: tag,
-      presets: [
-        {
-          name: name,
-        },
-      ],
+  section: (name, props = {}) => {
+    const tag = props.tag || 'section';
+    const presets = props.presets || [
+      { name }
+    ]
+
+    let obj = {
+      name,
+      tag,
+      ...methods.make(props),
+      presets
     };
+    
+    return obj;
   },
 
   _: (k) => methods.translate(k),


### PR DESCRIPTION
Existing section method could not receive additional props like class, presets etc. This enables the following:

```
module.exports = {
  ...app.section('Section Name', {
    class: 'section',
    tag: 'div',
    presets: [
      {
        name: "Section Preset Name",
        blocks: [
          {
            type: "heading"
          },
          {
            type: "paragraph"
          },
        ]
      }      
    ]
  }),
  settings: [...],
  blocks: [...]
}
```