### PR TITLE
Support type: "module" in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ const app = new Schematic({
 
 Then you're free to create schema definitions, either in full, partials, or whatever else. Here's some example Schematic schema JS for a Shopify section which renders a single icon and a heading.
 
+**Support for ES6:**
+_If your root package.json file has "type": "module", you should name your schema definition files with .cjs. Read more[ here](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_enabling)_
+
 First, some JS which exports objects we can reuse:
 ```js
-// ./src/schema/global.js
+// ./src/schema/global.js (or global.cjs)
 
 module.exports = {
   iconWidth: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alleyford/schematic",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Write Shopify schema with JS, not JSON.",
   "keywords": [
     "shopify",

--- a/src/schematic.js
+++ b/src/schematic.js
@@ -25,11 +25,25 @@ class Schematic {
 
   #preCheckOk = false;
 
+  // New field to store which extension to use
+  #schemaExt = 'js';
+
   //loader = require.resolve('./webpackLoader.js');
 
   constructor(opts = null) {
     if (opts) {
       this.#opts = opts;
+    }
+
+    // Check package.json for "type"
+    try {
+      const pkgPath = path.resolve(process.cwd(), 'package.json');
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+      if (pkg.type === 'module') {
+        this.#schemaExt = 'cjs';
+      }
+    } catch {
+      // fallback to 'js'
     }
   }
 
@@ -175,7 +189,8 @@ class Schematic {
     this.out(`exists. generating locales...`);
 
     fs.readdirSync(localePath).forEach(sourceFile => {
-      const localeFilename = sourceFile.replace('.js', '.json');
+      // Replace `.${this.#schemaExt}` with `.json`
+      const localeFilename = sourceFile.replace(`.${this.#schemaExt}`, '.json');
       const sourceLocalePath = path.resolve(localePath, sourceFile);
       const targetLocalePath = path.resolve(this.#opts.paths.locales, localeFilename);
 
@@ -198,9 +213,10 @@ class Schematic {
   }
 
   async buildConfig() {
-    this.out(`schematic: checking for ${this.#opts.paths.schema}/settings_schema.js...`);
+    // Use this.#schemaExt in the path and the log message
+    this.out(`schematic: checking for ${this.#opts.paths.schema}/settings_schema.${this.#schemaExt}...`);
 
-    const settingsSchema = path.resolve(this.#opts.paths.schema, `settings_schema.js`);
+    const settingsSchema = path.resolve(this.#opts.paths.schema, `settings_schema.${this.#schemaExt}`);
 
     if (!fs.existsSync(settingsSchema)) {
       this.out(`nothing to do\n`);
@@ -240,7 +256,7 @@ class Schematic {
     const files = {
       section: `${this.#opts.paths.sections}/${filename}.liquid`,
       snippet: `${this.#opts.paths.snippets}/${filename}.liquid`,
-      schema: `${this.#opts.paths.schema}/${filename}.js`,
+      schema: `${this.#opts.paths.schema}/${filename}.${this.#schemaExt}`,
     };
 
     for (const [type, file] of Object.entries(files)) {
@@ -283,7 +299,7 @@ class Schematic {
       }
     }
 
-    // from a simple filename or in a glob from relative path
+      // from a simple filename or in a glob from relative path
     catch(e) {
       floc = path.resolve(defaultPath, file);
       fstat = await fs.stat(floc);
@@ -349,9 +365,9 @@ class Schematic {
     return Promise.all(files.map(async file => {
       await this.runSection(file);
     }))
-    .catch(err => {
-      this.out(`${err}`, true);
-    });
+      .catch(err => {
+        this.out(`${err}`, true);
+      });
   }
 
   compileSchema(file) {
@@ -409,13 +425,15 @@ class Schematic {
       importFilename = filename;
     }
 
-    let importFile = path.resolve(this.#opts.paths.schema, `${importFilename}.js`);
+    // Use this.#schemaExt instead of hardcoding ".js"
+    let importFile = path.resolve(this.#opts.paths.schema, `${importFilename}.${this.#schemaExt}`);
 
     // doesn't exist, likely schematic options instead
     if (!fs.existsSync(importFile)) {
       opts = importFilename;
       importFilename = filename;
-      importFile = path.resolve(this.#opts.paths.schema, `${importFilename}.js`);
+      // Again, use this.#schemaExt
+      importFile = path.resolve(this.#opts.paths.schema, `${importFilename}.${this.#schemaExt}`);
     }
 
     const schema = this.compileSchema(importFile);
@@ -426,7 +444,7 @@ class Schematic {
 
     const newSchema = [
       '{% schema %}',
-        JSON.stringify(schema, null, 2),
+      JSON.stringify(schema, null, 2),
       '{% endschema %}',
     ].join('\n');
 


### PR DESCRIPTION
When **type** is set to **module** in a project's package.json, running schematic throws errors if schema definitions use the .js extension.

When **module** is set, a common js module should have the .cjs extension.

**Summary of changes:**
Check package.json type for "module". If it exists, then load all files in the schema definitions directory using .cjs instead of .js