### PR TITLE
Add default `id: section.id` in writeCode initialization.

### DIFF
--- a/src/schematic.js
+++ b/src/schematic.js
@@ -488,7 +488,7 @@ class Schematic {
 
 
   writeCode(contents, importFilename, schema) {
-    let lines = [], rendered = '';
+    let lines = ['id: section.id'], rendered = '';
 
     if (schema.settings) {
       for (const obj of schema.settings) {


### PR DESCRIPTION
This ensures `section.id` is always included in the switchboard code by default.